### PR TITLE
Add changes necessary to generate popolo for our councillor data

### DIFF
--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -309,7 +309,7 @@ class Popolo
           mem = {
             person_id:          r[:id],
             organization_id:    find_council_id(r[:council]),
-            role:               'member',
+            role:               'councillor',
             on_behalf_of_id:    r[:group_id] || find_party_id(r[:group]),
             area_id:            !r[:area_id].to_s.empty? ? r[:area_id] : !r[:area].to_s.empty? ? "area/#{_idify(r[:area])}" : nil,
             start_date:         r[:start_date],

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -35,6 +35,7 @@ class Popolo
     chamber: {
       aliases: %w(house)
     },
+    council: { },
     death_date: {
       aliases: %w(dod date_of_death),
       type: 'asis'

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -206,7 +206,11 @@ class Popolo
     end
 
     def memberships
-      legislative_memberships + executive_memberships
+      if councils.any?
+        council_memberships + executive_memberships
+      else
+        legislative_memberships + executive_memberships
+      end
     end
 
     def areas

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -212,7 +212,7 @@ class Popolo
 
     def memberships
       if councils.any?
-        council_memberships + executive_memberships
+        council_memberships + council_executive_memberships
       else
         legislative_memberships + executive_memberships
       end
@@ -320,6 +320,18 @@ class Popolo
         end
       else
         []
+      end
+    end
+
+    def council_executive_memberships
+      @council_emems ||= @csv.select { |r| r.key?(:executive) && !r[:executive].to_s.empty? }.map do |r|
+        mem = {
+          person_id:          r[:id],
+          organization_id:    find_council_id(r[:council]),
+          role:               r[:executive]
+        }
+        mem[:legislative_period] = "term/#{_idify(r[:term])}" if r.key? :term
+        mem
       end
     end
 

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -202,7 +202,7 @@ class Popolo
     end
 
     def organizations
-      parties + chambers + legislatures + executive
+      councils + parties + chambers + legislatures + executive
     end
 
     def memberships
@@ -225,6 +225,16 @@ class Popolo
           id: r[:group_id] || "party/#{_idify(r[:group])}",
           name: r[:group],
           classification: 'party'
+        }
+      end
+    end
+
+    def councils
+      @_councils ||= @csv.select { |r| r.key? :council }.uniq { |r| r.key?(:council_id) ? r[:council_id] : r[:council] }.map do |r|
+        {
+          id: r[:council_id] || "legislature/#{_idify(r[:council])}",
+          name: r[:council],
+          classification: 'legislature'
         }
       end
     end
@@ -318,6 +328,10 @@ class Popolo
 
     def find_party_id(name)
       (parties.find { |p| p[:name] == name } || return)[:id]
+    end
+
+    def find_council_id(name)
+      (councils.find { |p| p[:name] == name } || return)[:id]
     end
 
     def find_chamber_id(name)

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -202,7 +202,11 @@ class Popolo
     end
 
     def organizations
-      councils + parties + chambers + legislatures + executive
+      if councils.any?
+        councils + parties + chambers + executive
+      else
+        parties + chambers + legislatures + executive
+      end
     end
 
     def memberships

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -294,6 +294,26 @@ class Popolo
       end
     end
 
+    def council_memberships
+      if councils.any?
+        @csv.map do |r|
+          mem = {
+            person_id:          r[:id],
+            organization_id:    find_council_id(r[:council]),
+            role:               'member',
+            on_behalf_of_id:    r[:group_id] || find_party_id(r[:group]),
+            area_id:            !r[:area_id].to_s.empty? ? r[:area_id] : !r[:area].to_s.empty? ? "area/#{_idify(r[:area])}" : nil,
+            start_date:         r[:start_date],
+            end_date:           r[:end_date]
+          }.select { |_, v| !v.nil? }
+          mem[:legislative_period_id] = "term/#{_idify(r[:term])}" if r.key? :term
+          mem
+        end
+      else
+        []
+      end
+    end
+
     def executive_memberships
       @_emems ||= @csv.select { |r| r.key?(:executive) && !r[:executive].to_s.empty? }.map do |r|
         mem = {

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -204,7 +204,7 @@ class Popolo
 
     def organizations
       if councils.any?
-        councils + parties + chambers + executive
+        councils + parties + chambers
       else
         parties + chambers + legislatures + executive
       end

--- a/t/data/councillors.csv
+++ b/t/data/councillors.csv
@@ -1,0 +1,20 @@
+name,group,group_classification,executive,council_website
+Kevin Mack,Albury City Council,legistlature,Mayor,http://www.alburycity.nsw.gov.au
+Ross Jackson,Albury City Council,legislature,deputy mayor,http://www.alburycity.nsw.gov.au
+Daryl Betteridge,Albury City Council,legislature,,http://www.alburycity.nsw.gov.au
+Darren Cameron,Albury City Council,legislature,,http://www.alburycity.nsw.gov.au
+Graham Docksey,Albury City Council,legislature,,http://www.alburycity.nsw.gov.au
+Alice Glachan,Albury City Council,legislature,,http://www.alburycity.nsw.gov.au
+Patricia Gould,Albury City Council,legislature,,http://www.alburycity.nsw.gov.au
+David Thurley,Albury City Council,legislature,,http://www.alburycity.nsw.gov.au
+Henk van de Ven,Albury City Council,legislature,,http://www.alburycity.nsw.gov.au
+Herman Beyersdorf,Armidale Dumaresq Council,legislature,deputy mayor,http://www.armidale.nsw.gov.au
+Jenny Bailey,Armidale Dumaresq Council,legislature,,http://www.armidale.nsw.gov.au
+Laurie Bishop,Armidale Dumaresq Council,legislature,,http://www.armidale.nsw.gov.au
+Colin Gadd,Armidale Dumaresq Council,legislature,,http://www.armidale.nsw.gov.au
+Christopher Halligan,Armidale Dumaresq Council,legislature,,http://www.armidale.nsw.gov.au
+Jim Maher,Armidale Dumaresq Council,legislature,,http://www.armidale.nsw.gov.au
+Andrew Murat,Armidale Dumaresq Council,legislature,,http://www.armidale.nsw.gov.au
+Margaret O'Connor,Armidale Dumaresq Council,legislature,,http://www.armidale.nsw.gov.au
+Peter O'Donohue,Armidale Dumaresq Council,legislature,,http://www.armidale.nsw.gov.au
+Rob Richardson,Armidale Dumaresq Council,legislature,,http://www.armidale.nsw.gov.au

--- a/t/data/councillors.csv
+++ b/t/data/councillors.csv
@@ -1,20 +1,20 @@
-name,council,group_classification,executive,council_website
-Kevin Mack,Albury City Council,legistlature,Mayor,http://www.alburycity.nsw.gov.au
-Ross Jackson,Albury City Council,legislature,deputy mayor,http://www.alburycity.nsw.gov.au
-Daryl Betteridge,Albury City Council,legislature,,http://www.alburycity.nsw.gov.au
-Darren Cameron,Albury City Council,legislature,,http://www.alburycity.nsw.gov.au
-Graham Docksey,Albury City Council,legislature,,http://www.alburycity.nsw.gov.au
-Alice Glachan,Albury City Council,legislature,,http://www.alburycity.nsw.gov.au
-Patricia Gould,Albury City Council,legislature,,http://www.alburycity.nsw.gov.au
-David Thurley,Albury City Council,legislature,,http://www.alburycity.nsw.gov.au
-Henk van de Ven,Albury City Council,legislature,,http://www.alburycity.nsw.gov.au
-Herman Beyersdorf,Armidale Dumaresq Council,legislature,deputy mayor,http://www.armidale.nsw.gov.au
-Jenny Bailey,Armidale Dumaresq Council,legislature,,http://www.armidale.nsw.gov.au
-Laurie Bishop,Armidale Dumaresq Council,legislature,,http://www.armidale.nsw.gov.au
-Colin Gadd,Armidale Dumaresq Council,legislature,,http://www.armidale.nsw.gov.au
-Christopher Halligan,Armidale Dumaresq Council,legislature,,http://www.armidale.nsw.gov.au
-Jim Maher,Armidale Dumaresq Council,legislature,,http://www.armidale.nsw.gov.au
-Andrew Murat,Armidale Dumaresq Council,legislature,,http://www.armidale.nsw.gov.au
-Margaret O'Connor,Armidale Dumaresq Council,legislature,,http://www.armidale.nsw.gov.au
-Peter O'Donohue,Armidale Dumaresq Council,legislature,,http://www.armidale.nsw.gov.au
-Rob Richardson,Armidale Dumaresq Council,legislature,,http://www.armidale.nsw.gov.au
+name,council,executive,council_website
+Kevin Mack,Albury City Council,Mayor,http://www.alburycity.nsw.gov.au
+Ross Jackson,Albury City Council,deputy mayor,http://www.alburycity.nsw.gov.au
+Daryl Betteridge,Albury City Council,,http://www.alburycity.nsw.gov.au
+Darren Cameron,Albury City Council,,http://www.alburycity.nsw.gov.au
+Graham Docksey,Albury City Council,,http://www.alburycity.nsw.gov.au
+Alice Glachan,Albury City Council,,http://www.alburycity.nsw.gov.au
+Patricia Gould,Albury City Council,,http://www.alburycity.nsw.gov.au
+David Thurley,Albury City Council,,http://www.alburycity.nsw.gov.au
+Henk van de Ven,Albury City Council,,http://www.alburycity.nsw.gov.au
+Herman Beyersdorf,Armidale Dumaresq Council,deputy mayor,http://www.armidale.nsw.gov.au
+Jenny Bailey,Armidale Dumaresq Council,,http://www.armidale.nsw.gov.au
+Laurie Bishop,Armidale Dumaresq Council,,http://www.armidale.nsw.gov.au
+Colin Gadd,Armidale Dumaresq Council,,http://www.armidale.nsw.gov.au
+Christopher Halligan,Armidale Dumaresq Council,,http://www.armidale.nsw.gov.au
+Jim Maher,Armidale Dumaresq Council,,http://www.armidale.nsw.gov.au
+Andrew Murat,Armidale Dumaresq Council,,http://www.armidale.nsw.gov.au
+Margaret O'Connor,Armidale Dumaresq Council,,http://www.armidale.nsw.gov.au
+Peter O'Donohue,Armidale Dumaresq Council,,http://www.armidale.nsw.gov.au
+Rob Richardson,Armidale Dumaresq Council,,http://www.armidale.nsw.gov.au

--- a/t/data/councillors.csv
+++ b/t/data/councillors.csv
@@ -1,4 +1,4 @@
-name,group,group_classification,executive,council_website
+name,council,group_classification,executive,council_website
 Kevin Mack,Albury City Council,legistlature,Mayor,http://www.alburycity.nsw.gov.au
 Ross Jackson,Albury City Council,legislature,deputy mayor,http://www.alburycity.nsw.gov.au
 Daryl Betteridge,Albury City Council,legislature,,http://www.alburycity.nsw.gov.au

--- a/t/test_councillors.rb
+++ b/t/test_councillors.rb
@@ -27,4 +27,9 @@ describe 'councillors' do
       albury_council[:classification].must_equal 'legislature'
     end
   end
+
+  it 'does not create a default legislature' do
+    assert(organizations.none? { |org| org[:name] == "Legislature" },
+           'There are no organizations with default name "Legislature"')
+  end
 end

--- a/t/test_councillors.rb
+++ b/t/test_councillors.rb
@@ -56,6 +56,11 @@ describe 'councillors' do
            'There are no organizations with default name "Legislature"')
   end
 
+  it 'does not create a default executive organization' do
+    assert(organizations.none? { |org| org[:name] == "Executive" },
+           'There are no organizations with default name "Executive"')
+  end
+
   describe 'validation' do
     it 'does not say it has skipped the "council" column' do
       skipped_columns = subject.data[:warnings][:skipped]

--- a/t/test_councillors.rb
+++ b/t/test_councillors.rb
@@ -14,7 +14,7 @@ describe 'councillors' do
 
     it 'is associated with the correct council' do
       leg_mem = memberships.find { |m| m[:role] == 'member' }
-      member_org = organizations.find { |o| o[:id] == leg_mem[:on_behalf_of_id] }
+      member_org = organizations.find { |o| o[:id] == leg_mem[:organization_id] }
 
       member_org[:name].must_equal 'Albury City Council'
     end

--- a/t/test_councillors.rb
+++ b/t/test_councillors.rb
@@ -1,0 +1,22 @@
+require 'csv_to_popolo'
+require 'minitest/autorun'
+require 'json'
+
+describe 'councillors' do
+  subject     { Popolo::CSV.new('t/data/councillors.csv') }
+  let(:organizations)  { subject.data[:organizations] }
+
+  describe 'Patricia Gould' do
+    let(:patricia) { subject.data[:persons][6] }
+    let(:memberships) do
+      subject.data[:memberships].select { |m| m[:person_id] == patricia[:id] }
+    end
+
+    it 'is associated with the correct council' do
+      leg_mem = memberships.find { |m| m[:role] == 'member' }
+      member_org = organizations.find { |o| o[:id] == leg_mem[:on_behalf_of_id] }
+
+      member_org[:name].must_equal 'Albury City Council'
+    end
+  end
+end

--- a/t/test_councillors.rb
+++ b/t/test_councillors.rb
@@ -18,6 +18,29 @@ describe 'councillors' do
 
       member_org[:name].must_equal 'Albury City Council'
     end
+
+    it 'only has one membership as they are a non-executive councillor' do
+      assert memberships.count == 1
+    end
+  end
+
+  describe 'Kevin Mack' do
+    let(:kevin) { subject.data[:persons][0] }
+    let(:memberships) do
+      subject.data[:memberships].select { |m| m[:person_id] == kevin[:id] }
+    end
+
+    it 'has two memberships of their council' do
+      number_of_memberships_for_albury_council = memberships.count do |m|
+        m[:organization_id] == "legislature/albury_city_council"
+      end
+
+      assert number_of_memberships_for_albury_council == 2
+    end
+
+    it 'has the role of “Mayor”' do
+      assert memberships.any? { |m| m[:role] == 'Mayor' }
+    end
   end
 
   describe 'Albury City Council' do

--- a/t/test_councillors.rb
+++ b/t/test_councillors.rb
@@ -2,7 +2,7 @@ require 'csv_to_popolo'
 require 'minitest/autorun'
 require 'json'
 
-describe 'councillors' do
+describe 'councillors.csv' do
   subject     { Popolo::CSV.new('t/data/councillors.csv') }
   let(:organizations)  { subject.data[:organizations] }
 

--- a/t/test_councillors.rb
+++ b/t/test_councillors.rb
@@ -32,4 +32,12 @@ describe 'councillors' do
     assert(organizations.none? { |org| org[:name] == "Legislature" },
            'There are no organizations with default name "Legislature"')
   end
+
+  describe 'validation' do
+    it 'does not say it has skipped the "council" column' do
+      skipped_columns = subject.data[:warnings][:skipped]
+
+      assert !skipped_columns.include?(:council)
+    end
+  end
 end

--- a/t/test_councillors.rb
+++ b/t/test_councillors.rb
@@ -13,7 +13,7 @@ describe 'councillors' do
     end
 
     it 'is associated with the correct council' do
-      leg_mem = memberships.find { |m| m[:role] == 'member' }
+      leg_mem = memberships.find { |m| m[:role] == 'councillor' }
       member_org = organizations.find { |o| o[:id] == leg_mem[:organization_id] }
 
       member_org[:name].must_equal 'Albury City Council'

--- a/t/test_councillors.rb
+++ b/t/test_councillors.rb
@@ -19,4 +19,12 @@ describe 'councillors' do
       member_org[:name].must_equal 'Albury City Council'
     end
   end
+
+  describe 'Albury City Council' do
+    it 'has the correct classification' do
+      albury_council = organizations[0]
+
+      albury_council[:classification].must_equal 'legislature'
+    end
+  end
 end


### PR DESCRIPTION
The [upstream csv_to_popolo](https://github.com/tmtmtmtm/csv_to_popolo) works for people who are members of a federal legislature, but not local councillors. These changes adapt it for use with Australian local councillor data so it can be used to generate the data for https://github.com/openaustralia/australian_local_councillors_popolo .
